### PR TITLE
Hardcode location of OEM fonts

### DIFF
--- a/Resources/DefaultSettings.rpy
+++ b/Resources/DefaultSettings.rpy
@@ -100,14 +100,8 @@ init -10000 python:
     }
 
 init -50000:
-    default aliceos.oem_mode = False
-    default aliceos.oem_font_regular = None
-    default aliceos.oem_font_bold = None
-    default aliceos.oem_font_italic = None
-    default aliceos.oem_font_black = None
-    default alceos.oem_font_thin = None
-    default aliceos.oem_font_medium = None
     default aliceos.oem_large_pisa_font = False
+    default aliceos.oem_mode = False
 
     default aliceos.font_regular = "Resources/systemfont/Regular.ttf"
     default aliceos.font_bold = "Resources/systemfont/Bold.ttf"

--- a/Resources/OEMSettings.rpy
+++ b/Resources/OEMSettings.rpy
@@ -33,16 +33,12 @@ No license found.
 ## Brand configurations
 ##################################################
 
-## Define the AliceOS OEM Fonts here. This covers
-## required font weights to match the standard
-## system.
+## Define whether to use custom fonts in all of
+## AliceOS. Fonts will need to be placed in the
+## Resources/systemfont/OEM folder and match the
+## font structure of AliceOS's fonts.
 
-define aliceos.oem_font_regular = ""
-define aliceos.oem_font_bold = ""
-define aliceos.oem_font_italic = ""
-define aliceos.oem_font_black = ""
-define alceos.oem_font_thin = ""
-define aliceos.oem_font_medium = ""
+define aliceos.oem_use_custom_font = False
 
 ## Define the AliceOS OEM Colors here. This covers
 ## branding colors scaling from the 100 (lightest)
@@ -68,4 +64,4 @@ init -10 python:
 ## the Setup screen. The font sizes will adjust
 ## accordingly.
 
-define aliceos.oem_large_pisa_font = False
+define aliceos.oem_large_pisa_font = True

--- a/Resources/UIStyles.rpy
+++ b/Resources/UIStyles.rpy
@@ -24,54 +24,54 @@ init 2:
     style setup_mute_text is gui_prompt_text
 
     # Fonts
-    if aliceos.oem_mode:
+    if aliceos.oem_mode and aliceos.oem_use_custom_font:
         style aliceos_regular is default:
-            font aliceos.oem_font_regular
+            font "Resources/systemfont/OEM/Regular.ttf"
             outlines []
 
         style aliceos_bold is default:
-            font aliceos.oem_font_bold
+            font "Resources/systemfont/OEM/Bold.ttf"
             outlines []
 
         style aliceos_medium is default:
-            font aliceos.oem_font_medium
+            font "Resources/systemfont/OEM/Medium.ttf"
             outlines []
 
         style aliceos_black is default:
-            font aliceos.oem_font_black
+            font "Resources/systemfont/OEM/Black.ttf"
             outlines []
 
         style aliceos_italic is default:
-            font aliceos.oem_font_italic
+            font "Resources/systemfont/OEM/Italic.ttf"
             outlines []
 
         style aliceos_thin is default:
-            font aliceos.oem_font_regular
+            font "Resources/systemfont/OEM/Thin.ttf"
             outlines []
 
     else:
         style aliceos_regular is default:
-            font aliceos.font_regular
+            font "Resources/systemfont/Regular.ttf"
             outlines []
 
         style aliceos_bold is default:
-            font aliceos.font_bold
+            font "Resources/systemfont/Bold.ttf"
             outlines []
 
         style aliceos_medium is default:
-            font aliceos.font_medium
+            font "Resources/systemfont/Medium.ttf"
             outlines []
 
         style aliceos_black is default:
-            font aliceos.font_black
+            font "Resources/systemfont/Black.ttf"
             outlines []
 
         style aliceos_italic is default:
-            font aliceos.font_italic
+            font "Resources/systemfont/Italic.ttf"
             outlines []
 
         style aliceos_thin is default:
-            font aliceos.font_regular
+            font "Resources/systemfont/Thin.ttf"
             outlines []
 
 
@@ -240,3 +240,22 @@ init 2:
     style aliceos_input_text is aliceos_italic:
         color blueberry[500]
 
+
+    ## ASErrorHandler Styles
+    style rsod_emoticon is aliceos_regular:
+        size 128
+        color strawberry[100]
+
+    style rsod_title_text is aliceos_regular:
+        size 48
+        text_align 0.0
+        color "#ffffff"
+
+    style rsod_prompt_text is aliceos_thin:
+        color strawberry[100]
+        text_align 0.0
+        size 24
+
+    style rsod_error_text is aliceos_medium:
+        size 24
+        color "#ffffff"


### PR DESCRIPTION
Now works with a set of toggles rather than strings.

This should resolve #22 .